### PR TITLE
Output `ram_resource_share_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,14 +493,16 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] |
-|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![RB][nitrocode_avatar]][nitrocode_homepage]<br/>[RB][nitrocode_homepage] |
+|---|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
   [aknysh_homepage]: https://github.com/aknysh
   [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
+  [nitrocode_homepage]: https://github.com/nitrocode
+  [nitrocode_avatar]: https://img.cloudposse.com/150x150/https://github.com/nitrocode.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Available targets:
 
 | Name | Description |
 |------|-------------|
+| <a name="output_ram_resource_share_id"></a> [ram\_resource\_share\_id](#output\_ram\_resource\_share\_id) | RAM resource share ID |
 | <a name="output_subnet_route_ids"></a> [subnet\_route\_ids](#output\_subnet\_route\_ids) | Subnet route identifiers combined with destinations |
 | <a name="output_transit_gateway_arn"></a> [transit\_gateway\_arn](#output\_transit\_gateway\_arn) | Transit Gateway ARN |
 | <a name="output_transit_gateway_association_default_route_table_id"></a> [transit\_gateway\_association\_default\_route\_table\_id](#output\_transit\_gateway\_association\_default\_route\_table\_id) | Transit Gateway association default route table ID |

--- a/README.yaml
+++ b/README.yaml
@@ -222,3 +222,5 @@ contributors:
     github: "osterman"
   - name: "Andriy Knysh"
     github: "aknysh"
+  - name: "RB"
+    github: "nitrocode"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -84,6 +84,7 @@
 
 | Name | Description |
 |------|-------------|
+| <a name="output_ram_resource_share_id"></a> [ram\_resource\_share\_id](#output\_ram\_resource\_share\_id) | RAM resource share ID |
 | <a name="output_subnet_route_ids"></a> [subnet\_route\_ids](#output\_subnet\_route\_ids) | Subnet route identifiers combined with destinations |
 | <a name="output_transit_gateway_arn"></a> [transit\_gateway\_arn](#output\_transit\_gateway\_arn) | Transit Gateway ARN |
 | <a name="output_transit_gateway_association_default_route_table_id"></a> [transit\_gateway\_association\_default\_route\_table\_id](#output\_transit\_gateway\_association\_default\_route\_table\_id) | Transit Gateway association default route table ID |

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,8 @@ output "subnet_route_ids" {
   value       = try({ for i, o in module.subnet_route : i => o["subnet_route_ids"] }, {})
   description = "Subnet route identifiers combined with destinations"
 }
+
+output "ram_resource_share_id" {
+  value       = try(aws_ram_resource_share.default[0].id, "")
+  description = "RAM resource share ID"
+}


### PR DESCRIPTION
## what
* Output `ram_resource_share_id`

## why
* In case additional principals need to be associated to the ram resource share
* At the moment, if var.ram_principal is passed in, the org data source is replaced, and there is no way to pass in multiple ram principals
* Easiest solution is to export the ram resource share id and associate from outside the module

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_principal_association

