### PR TITLE
Bump aws provider to v4.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.4.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
 
@@ -245,7 +245,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.4.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -238,8 +238,6 @@ Available targets:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.4.0 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
 
 ## Providers
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.4.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
 
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.4.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,8 +5,6 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.4.0 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
 
 ## Providers
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -2,17 +2,9 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.2"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 2.2"
-    }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 4.4.0"
     }
   }
 }

--- a/examples/multi-account/versions.tf
+++ b/examples/multi-account/versions.tf
@@ -2,17 +2,9 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.2"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 2.2"
-    }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 4.4.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,14 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.2"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 2.2"
-    }
     aws = {
       source  = "hashicorp/aws"
       version = ">= 4.4.0"

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 4.4.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Bump aws provider to v4.4.0

## why
* Prevent people from using an older provider version which would cause issues

## references
* https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.4.0
* Previous PR https://github.com/cloudposse/terraform-aws-transit-gateway/pull/20
* Closes https://github.com/cloudposse/terraform-aws-transit-gateway/issues/24

