### PR TITLE
Fix flickering when transit gateway description is not set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ locals {
 
 resource "aws_ec2_transit_gateway" "default" {
   count                           = module.this.enabled && var.create_transit_gateway ? 1 : 0
-  description                     = var.transit_gateway_description == "" ? format("%s Transit Gateway", module.this.id) : var.transit_gateway_description
+  description                     = var.transit_gateway_description == "" ? format("%sTransit Gateway", module.this.id) : var.transit_gateway_description
   auto_accept_shared_attachments  = var.auto_accept_shared_attachments
   default_route_table_association = var.default_route_table_association
   default_route_table_propagation = var.default_route_table_propagation


### PR DESCRIPTION
## what

This PR fixes flickering on every Terraform run when *var.transit_gateway_description* is unset.

The problem is caused by the leading space in the description: something that AWS APIs accept without erroring out or warning, but which gets removed or ignored. Hence Terraform tries to "fix" the situation on every run.

## why

Without this change this happens on every Terraform run if *var.transit_gateway_description* is not defined:

```
Terraform will perform the following actions:                                                             

  # module.transit_gateway.aws_ec2_transit_gateway.default[0] will be updated in-place                    
  ~ resource "aws_ec2_transit_gateway" "default" {   
      ~ description                     = "Transit Gateway" -> " Transit Gateway"                         
        id                              = "tgw-07987d7d0a101968b"                                         
        tags                            = {}         
        # (11 unchanged attributes hidden)           
    }                                                

Plan: 0 to add, 1 to change, 0 to destroy.           
```

With this change applied things work as expected:

```
No changes. Your infrastructure matches the configuration.
```