### PR TITLE
Update README.yaml

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -84,7 +84,7 @@ description: |-
 
   - [AWS Transit Gateway](https://aws.amazon.com/transit-gateway/)
   - [AWS Resource Access Manager (AWS RAM)](https://docs.aws.amazon.com/ram/latest/userguide/what-is.html) Resource Share to share the Transit Gateway with
-    the Organization or another AWS Account (configurable via the variables `ram_resource_share_enabled` and `ram_principal`)
+    the Organization or another AWS Account (configurable via the variables `ram_resource_share_enabled` and `ram_principals`)
   - [Transit Gateway route table](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-route-tables.html)
   - [Transit Gateway VPC attachments](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-vpc-attachments.html) to connect multiple VPCs via the Transit Gateway
   - Transit Gateway route table propagations to create propagated routes and allow traffic from the Transit Gateway to the VPC attachments


### PR DESCRIPTION
ram_principal is deprecated as per source code.
We should now be using ram_principals variable in the module

## what

<!--
The documenation is not aliged with the source code.
-->

## why

<!--
It helps others use the correct variable when using the module as the documenation is incorrect
-->

## references

<!--
[- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`](https://github.com/cloudposse/terraform-aws-transit-gateway/blob/main/variables.tf)
- As Per line 11
-->
