### PR TITLE
feat: Support enabling Security Group Referencing support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,8 @@ resource "aws_ec2_transit_gateway" "default" {
   vpn_ecmp_support                = var.vpn_ecmp_support
   tags                            = module.this.tags
   transit_gateway_cidr_blocks     = var.transit_gateway_cidr_blocks
+
+  security_group_referencing_support = var.security_group_referencing_support
 }
 
 resource "aws_ec2_transit_gateway_route_table" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -152,6 +152,12 @@ variable "route_keys_enabled" {
     EOT
 }
 
+variable "security_group_referencing_support" {
+  type        = string
+  default     = "disable"
+  description = "Whether Security Group Referencing Support is enabled. Valid values: `disable`, `enable`. Default value: `disable`"
+}
+
 variable "transit_gateway_cidr_blocks" {
   type        = list(string)
   default     = null


### PR DESCRIPTION
## what

Adding a configuration variable to control Security Group Referencing support

## why

We want to reference the security groups from a different account (core-network) where we have a third-party service connected by Private Link (MongoDB Atlas)
