### PR TITLE
feat: allow sg referencing support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,10 +16,12 @@ resource "aws_ec2_transit_gateway" "default" {
   auto_accept_shared_attachments  = var.auto_accept_shared_attachments
   default_route_table_association = var.default_route_table_association
   default_route_table_propagation = var.default_route_table_propagation
-  dns_support                     = var.dns_support
-  vpn_ecmp_support                = var.vpn_ecmp_support
-  tags                            = module.this.tags
-  transit_gateway_cidr_blocks     = var.transit_gateway_cidr_blocks
+
+  security_group_referencing_support = var.security_group_referencing_support
+  dns_support                        = var.dns_support
+  vpn_ecmp_support                   = var.vpn_ecmp_support
+  tags                               = module.this.tags
+  transit_gateway_cidr_blocks        = var.transit_gateway_cidr_blocks
 }
 
 resource "aws_ec2_transit_gateway_route_table" "default" {

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "aws_ec2_transit_gateway" "default" {
   auto_accept_shared_attachments     = var.auto_accept_shared_attachments
   default_route_table_association    = var.default_route_table_association
   default_route_table_propagation    = var.default_route_table_propagation
-  security_group_referencing_support = var.security_group_referencing_support
+  security_group_referencing_support = var.security_group_referencing_support_enabled ? "enable" : "disable"
   dns_support                        = var.dns_support
   vpn_ecmp_support                   = var.vpn_ecmp_support
   tags                               = module.this.tags

--- a/main.tf
+++ b/main.tf
@@ -11,12 +11,11 @@ locals {
 }
 
 resource "aws_ec2_transit_gateway" "default" {
-  count                           = module.this.enabled && var.create_transit_gateway ? 1 : 0
-  description                     = var.transit_gateway_description == "" ? format("%s Transit Gateway", module.this.id) : var.transit_gateway_description
-  auto_accept_shared_attachments  = var.auto_accept_shared_attachments
-  default_route_table_association = var.default_route_table_association
-  default_route_table_propagation = var.default_route_table_propagation
-
+  count                              = module.this.enabled && var.create_transit_gateway ? 1 : 0
+  description                        = var.transit_gateway_description == "" ? format("%s Transit Gateway", module.this.id) : var.transit_gateway_description
+  auto_accept_shared_attachments     = var.auto_accept_shared_attachments
+  default_route_table_association    = var.default_route_table_association
+  default_route_table_propagation    = var.default_route_table_propagation
   security_group_referencing_support = var.security_group_referencing_support
   dns_support                        = var.dns_support
   vpn_ecmp_support                   = var.vpn_ecmp_support

--- a/modules/subnet_route/variables.tf
+++ b/modules/subnet_route/variables.tf
@@ -14,8 +14,9 @@ variable "destination_cidr_blocks" {
 }
 
 variable "route_keys_enabled" {
-  type    = bool
-  default = false
+  type        = bool
+  description = "Enable route keys"
+  default     = false
 }
 
 variable "route_timeouts" {

--- a/modules/subnet_route/versions.tf
+++ b/modules/subnet_route/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.4.0"
+    }
+  }
+}

--- a/modules/subnet_route/versions.tf
+++ b/modules/subnet_route/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.4.0"
+      version = ">= 5.69.0"
     }
   }
 }

--- a/modules/transit_gateway_route/versions.tf
+++ b/modules/transit_gateway_route/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.4.0"
+    }
+  }
+}

--- a/modules/transit_gateway_route/versions.tf
+++ b/modules/transit_gateway_route/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.4.0"
+      version = ">= 5.69.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -49,14 +49,10 @@ variable "default_route_table_propagation" {
   description = "Whether resource attachments automatically propagate routes to the default propagation route table. Valid values: `disable`, `enable`. Default value: `disable`"
 }
 
-variable "security_group_referencing_support" {
-  description = "Enable or disable support for referencing security groups across VPCs in the transit gateway. Valid values: 'enable', 'disable'."
-  type        = string
-  default     = "disable"
-  validation {
-    condition     = contains(["enable", "disable"], var.security_group_referencing_support)
-    error_message = "security_group_referencing_support must be either 'enable' or 'disable'."
-  }
+variable "security_group_referencing_support_enabled" {
+  description = "Enable or disable support for referencing security groups across VPCs in the transit gateway."
+  type        = bool
+  default     = false
 }
 
 variable "dns_support" {

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,10 @@ variable "security_group_referencing_support" {
   description = "Enable or disable support for referencing security groups across VPCs in the transit gateway. Valid values: 'enable', 'disable'."
   type        = string
   default     = "disable"
+  validation {
+    condition     = var.security_group_referencing_support == "enable" || var.security_group_referencing_support == "disable"
+    error_message = "security_group_referencing_support must be either 'enable' or 'disable'."
+  }
 }
 
 variable "dns_support" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-variable "security_group_referencing_support" {
-  description = "Enable or disable support for referencing security groups across VPCs in the transit gateway. Valid values: 'enable', 'disable'."
-  type        = string
-  default     = "disable"
-}
 variable "ram_resource_share_enabled" {
   type        = bool
   default     = false
@@ -52,6 +47,12 @@ variable "default_route_table_propagation" {
   type        = string
   default     = "disable"
   description = "Whether resource attachments automatically propagate routes to the default propagation route table. Valid values: `disable`, `enable`. Default value: `disable`"
+}
+
+variable "security_group_referencing_support" {
+  description = "Enable or disable support for referencing security groups across VPCs in the transit gateway. Valid values: 'enable', 'disable'."
+  type        = string
+  default     = "disable"
 }
 
 variable "dns_support" {

--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,7 @@ variable "security_group_referencing_support" {
   type        = string
   default     = "disable"
   validation {
-    condition     = var.security_group_referencing_support == "enable" || var.security_group_referencing_support == "disable"
+    condition     =  contains(["enable", "disable"], var.security_group_referencing_support)
     error_message = "security_group_referencing_support must be either 'enable' or 'disable'."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,9 +50,9 @@ variable "default_route_table_propagation" {
 }
 
 variable "security_group_referencing_support_enabled" {
-  description = "Enable or disable support for referencing security groups across VPCs in the transit gateway."
   type        = bool
   default     = false
+  description = "Enable or disable support for referencing security groups across VPCs in the transit gateway."
 }
 
 variable "dns_support" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "security_group_referencing_support" {
+  description = "Enable or disable support for referencing security groups across VPCs in the transit gateway. Valid values: 'enable', 'disable'."
+  type        = string
+  default     = "disable"
+}
 variable "ram_resource_share_enabled" {
   type        = bool
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,7 @@ variable "security_group_referencing_support" {
   type        = string
   default     = "disable"
   validation {
-    condition     =  contains(["enable", "disable"], var.security_group_referencing_support)
+    condition     = contains(["enable", "disable"], var.security_group_referencing_support)
     error_message = "security_group_referencing_support must be either 'enable' or 'disable'."
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.4.0"
+      version = ">= 5.69.0"
     }
   }
 }


### PR DESCRIPTION
## what

- Allow users to enable SG support for transit gateway

## why

- Allows SG referencing when using transit gateways from other accounts

## references

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway#security_group_referencing_support-1
- closes #63

